### PR TITLE
fix(schedule): вернуть модалку дня в вид «Месяц»

### DIFF
--- a/__tests__/Schedule.test.tsx
+++ b/__tests__/Schedule.test.tsx
@@ -1,5 +1,11 @@
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
-import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import {
+  fireEvent,
+  render,
+  screen,
+  waitFor,
+  within,
+} from "@testing-library/react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { SchedulePage } from "@/pages/Schedule";
 import { useAuthStore } from "@/store/auth";
@@ -118,6 +124,41 @@ describe("SchedulePage", () => {
       expect(saveScheduleImage).toHaveBeenCalledOnce();
     });
     expect(drawScheduleImage).toHaveBeenCalledOnce();
+    expect(screen.queryByRole("dialog")).toBeNull();
+  });
+
+  it("opens a day dialog from the month grid", () => {
+    const client = new QueryClient({
+      defaultOptions: {
+        queries: { retry: false, staleTime: Infinity, gcTime: Infinity },
+      },
+    });
+    seedWeek(client, [lesson()]);
+    renderPage(client);
+
+    fireEvent.click(screen.getByRole("button", { name: "2026-09-01, 1 пара" }));
+
+    const dialog = screen.getByRole("dialog");
+    expect(within(dialog).getByText("ASP.NET")).toBeTruthy();
+    expect(within(dialog).getByText("08:00–09:20")).toBeTruthy();
+    expect(within(dialog).getByText("Онлайн 1")).toBeTruthy();
+    expect(screen.getByText("1 сентября 2026 г.")).toBeTruthy();
+  });
+
+  it("closes the day dialog when the view changes", () => {
+    const client = new QueryClient({
+      defaultOptions: {
+        queries: { retry: false, staleTime: Infinity, gcTime: Infinity },
+      },
+    });
+    seedWeek(client, [lesson()]);
+    renderPage(client);
+
+    fireEvent.click(screen.getByRole("button", { name: "2026-09-01, 1 пара" }));
+    expect(screen.getByRole("dialog")).toBeTruthy();
+
+    fireEvent.click(screen.getByRole("tab", { name: "День" }));
+
     expect(screen.queryByRole("dialog")).toBeNull();
   });
 

--- a/src/components/schedule/DayDialog.tsx
+++ b/src/components/schedule/DayDialog.tsx
@@ -1,0 +1,33 @@
+import { LessonCard } from "./LessonCard";
+import { Modal } from "@/components/ui/Modal";
+import { WEEKDAYS_FULL } from "@/constants/constants";
+import { formatFullDate } from "@/lib/format";
+import { pluralRu } from "@/utils/pluralRu";
+import type { ScheduleLesson } from "@/types";
+
+type DayDialogProps = {
+  date: Date;
+  lessons: ScheduleLesson[];
+  onClose: () => void;
+};
+
+export const DayDialog = ({ date, lessons, onClose }: DayDialogProps) => (
+  <Modal
+    title={formatFullDate(date)}
+    description={`${WEEKDAYS_FULL[(date.getDay() + 6) % 7]} · ${lessons.length} ${pluralRu(
+      lessons.length,
+      ["пара", "пары", "пар"],
+    )}`}
+    onClose={onClose}
+  >
+    {lessons.length ? (
+      <ul className="flex flex-col gap-2">
+        {lessons.map((lesson) => (
+          <LessonCard key={lesson.lesson} lesson={lesson} />
+        ))}
+      </ul>
+    ) : (
+      <p className="py-6 text-center text-sm text-ink-500">В этот день пар нет</p>
+    )}
+  </Modal>
+);

--- a/src/components/schedule/LessonCard.tsx
+++ b/src/components/schedule/LessonCard.tsx
@@ -1,0 +1,32 @@
+import { Clock, MapPin, User } from "lucide-react";
+import { formatTime } from "@/lib/format";
+import type { ScheduleLesson } from "@/types";
+
+export const LessonCard = ({ lesson }: { lesson: ScheduleLesson }) => (
+  <li className="flex gap-3 rounded-xl border border-line bg-surface p-3">
+    <span className="grid size-8 shrink-0 place-items-center rounded-lg bg-brand-600 text-xs font-semibold text-white tabular-nums">
+      {lesson.lesson}
+    </span>
+
+    <div className="min-w-0 flex-1">
+      <p className="text-sm font-medium break-words text-ink-50">
+        {lesson.subject_name}
+      </p>
+
+      <div className="mt-1.5 flex flex-col gap-1 text-xs text-ink-300">
+        <span className="inline-flex items-center gap-1.5 tabular-nums">
+          <Clock className="size-3.5 shrink-0" aria-hidden />
+          {formatTime(lesson.started_at)}–{formatTime(lesson.finished_at)}
+        </span>
+        <span className="inline-flex items-center gap-1.5">
+          <MapPin className="size-3.5 shrink-0" aria-hidden />
+          {lesson.room_name}
+        </span>
+        <span className="inline-flex items-start gap-1.5 break-words">
+          <User className="mt-0.5 size-3.5 shrink-0" aria-hidden />
+          {lesson.teacher_name}
+        </span>
+      </div>
+    </div>
+  </li>
+);

--- a/src/pages/Schedule.tsx
+++ b/src/pages/Schedule.tsx
@@ -1,6 +1,7 @@
 import { useQuery } from "@tanstack/react-query";
 import { Camera, ChevronLeft, ChevronRight } from "lucide-react";
 import { useMemo, useState } from "react";
+import { DayDialog } from "@/components/schedule/DayDialog";
 import { MonthView } from "@/components/schedule/MonthView";
 import { ScheduleTable } from "@/components/schedule/ScheduleTable";
 import { Card, CardBody } from "@/components/ui/Card";
@@ -47,6 +48,7 @@ const shiftLabel = (view: ScheduleView, direction: -1 | 1) => {
 export const SchedulePage = () => {
   const [view, setView] = useState<ScheduleView>("month");
   const [cursor, setCursor] = useState(() => new Date());
+  const [selectedDay, setSelectedDay] = useState<Date | null>(null);
   const [saving, setSaving] = useState(false);
   const today = new Date();
   const groupName = useAuthStore((state) => state.user?.group_name);
@@ -80,6 +82,7 @@ export const SchedulePage = () => {
   );
 
   const shift = (direction: -1 | 1) => {
+    setSelectedDay(null);
     setCursor((prev) => {
       if (view === "month") {
         return addMonths(prev, direction);
@@ -87,6 +90,11 @@ export const SchedulePage = () => {
 
       return addDays(prev, view === "week" ? direction * 7 : direction);
     });
+  };
+
+  const switchView = (next: ScheduleView) => {
+    setSelectedDay(null);
+    setView(next);
   };
 
   const weekLabel = `${formatDate(weekStart)} — ${formatDate(weekEnd)}`;
@@ -140,7 +148,7 @@ export const SchedulePage = () => {
         <Segmented
           options={VIEW_OPTIONS}
           value={view}
-          onChange={setView}
+          onChange={switchView}
           ariaLabel="Вид расписания"
           className="w-auto max-w-full shrink-0 flex-nowrap [&_[role=tab]]:basis-0"
         />
@@ -214,10 +222,7 @@ export const SchedulePage = () => {
                 anchor={monthAnchor}
                 lessonsByDate={lessonsByDate}
                 today={today}
-                onSelectDay={(date) => {
-                  setCursor(date);
-                  setView("day");
-                }}
+                onSelectDay={setSelectedDay}
               />
             ) : (
               <div className="-mx-5">
@@ -232,6 +237,14 @@ export const SchedulePage = () => {
           </CardBody>
         )}
       </Card>
+
+      {selectedDay ? (
+        <DayDialog
+          date={selectedDay}
+          lessons={lessonsByDate.get(toIsoDate(selectedDay)) ?? []}
+          onClose={() => setSelectedDay(null)}
+        />
+      ) : null}
     </div>
   );
 };


### PR DESCRIPTION
Клик по дню в сетке месяца снова открывает список пар в модалке, вместо переключения на отдельный вид дня.