### PR TITLE
fix(a11y): пометить активную вкладку «Другое» и заголовки строк распи…

### DIFF
--- a/__tests__/MarksPagination.test.tsx
+++ b/__tests__/MarksPagination.test.tsx
@@ -2,7 +2,7 @@ import { render, screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { describe, expect, it } from "vitest";
 import Marks from "@/components/Marks";
-import { LESSONS_PER_PAGE } from "@/constants/constants";
+import { LESSONS_LOAD_MORE, LESSONS_PER_PAGE } from "@/constants/constants";
 import type { StudentVisit } from "@/types";
 
 const visits = (count: number): StudentVisit[] =>
@@ -52,20 +52,20 @@ describe("Marks", () => {
     const user = userEvent.setup();
     render(<Marks marks={visits(120)} />);
 
-    await user.click(screen.getByRole("button", { name: "+50" }));
+    await user.click(screen.getByRole("button", { name: "Показать ещё" }));
 
-    expect(rows()).toHaveLength(LESSONS_PER_PAGE + 50);
+    expect(rows()).toHaveLength(LESSONS_PER_PAGE + LESSONS_LOAD_MORE);
     expect(rows()[0].textContent).toBe("Пара 120");
   });
 
-  it("offers the remaining count when fewer than fifty are left", async () => {
+  it("hides the load more button once the tail is shown", async () => {
     const user = userEvent.setup();
     render(<Marks marks={visits(45)} />);
 
-    await user.click(screen.getByRole("button", { name: "+25" }));
+    await user.click(screen.getByRole("button", { name: "Показать ещё" }));
 
     expect(rows()).toHaveLength(45);
-    expect(screen.queryByRole("button", { name: /^\+\d+$/ })).toBeNull();
+    expect(screen.queryByRole("button", { name: "Показать ещё" })).toBeNull();
   });
 
   it("keeps pagination hidden for short lists", () => {

--- a/src/components/layout/TabBar.tsx
+++ b/src/components/layout/TabBar.tsx
@@ -1,5 +1,5 @@
-import { NavLink, useLocation } from "react-router";
-import { isMorePath, TAB_ITEMS } from "./nav";
+import { Link, matchPath, useLocation } from "react-router";
+import { isMorePath, TAB_ITEMS, type TabItem } from "./nav";
 import { Counter } from "@/components/ui/Controls";
 import { cn } from "@/lib/cn";
 
@@ -7,9 +7,13 @@ type TabBarProps = {
   badges: Record<string, number>;
 };
 
+const isTabActive = (item: TabItem, pathname: string) =>
+  item.to === "/more"
+    ? isMorePath(pathname)
+    : Boolean(matchPath({ path: item.to, end: item.to === "/" }, pathname));
+
 export const TabBar = ({ badges }: TabBarProps) => {
-  const location = useLocation();
-  const moreActive = isMorePath(location.pathname);
+  const { pathname } = useLocation();
 
   return (
     <nav
@@ -19,64 +23,48 @@ export const TabBar = ({ badges }: TabBarProps) => {
       <ul className="grid grid-cols-5">
         {TAB_ITEMS.map((item) => {
           const badge = badges[item.to] ?? 0;
+          const active = isTabActive(item, pathname);
+          const Icon = item.icon;
 
           return (
             <li key={item.to} className="min-w-0">
-              <NavLink
+              <Link
                 to={item.to}
-                end={item.to === "/" || item.to === "/more"}
-                aria-current={
-                  item.to === "/more" ? (moreActive ? "page" : false) : undefined
-                }
-                className={({ isActive }) => {
-                  const active = item.to === "/more" ? moreActive : isActive;
-
-                  return cn(
-                    "flex h-16 min-w-0 flex-col items-center justify-end gap-1 px-1 pb-2",
-                    active ? "text-heading" : "text-ink-400",
-                    item.featured && "text-brand-300",
-                  );
-                }}
+                aria-current={active ? "page" : undefined}
+                className={cn(
+                  "flex h-16 min-w-0 flex-col items-center justify-end gap-1 px-1 pb-2",
+                  active ? "text-heading" : "text-ink-400",
+                  item.featured && "text-brand-300",
+                )}
               >
-                {({ isActive }) => {
-                  const active = item.to === "/more" ? moreActive : isActive;
-                  const Icon = item.icon;
-
-                  return (
-                    <>
-                      <span
-                        className={cn(
-                          "relative grid size-10 shrink-0 place-items-center",
-                          item.featured &&
-                            "rounded-2xl bg-brand-600 text-white shadow-[0_8px_20px_rgb(112_36_247_/_0.4)]",
-                        )}
-                      >
-                        <Icon
-                          className={cn(
-                            item.featured
-                              ? "size-5 text-white"
-                              : "size-5",
-                            !item.featured &&
-                              (active ? "text-heading" : "text-ink-400"),
-                          )}
-                          aria-hidden
-                        />
-                        {badge ? (
-                          <span className="absolute -top-1 -right-1">
-                            <Counter
-                              value={badge}
-                              label={`Новых заданий: ${badge}`}
-                            />
-                          </span>
-                        ) : null}
-                      </span>
-                      <span className="h-3 w-full truncate text-center text-[10px] leading-3 font-medium">
-                        {item.label}
-                      </span>
-                    </>
-                  );
-                }}
-              </NavLink>
+                <span
+                  className={cn(
+                    "relative grid size-10 shrink-0 place-items-center",
+                    item.featured &&
+                      "rounded-2xl bg-brand-600 text-white shadow-[0_8px_20px_rgb(112_36_247_/_0.4)]",
+                  )}
+                >
+                  <Icon
+                    className={cn(
+                      "size-5",
+                      item.featured
+                        ? "text-white"
+                        : active
+                          ? "text-heading"
+                          : "text-ink-400",
+                    )}
+                    aria-hidden
+                  />
+                  {badge ? (
+                    <span className="absolute -top-1 -right-1">
+                      <Counter value={badge} label={`Новых заданий: ${badge}`} />
+                    </span>
+                  ) : null}
+                </span>
+                <span className="h-3 w-full truncate text-center text-[10px] leading-3 font-medium">
+                  {item.label}
+                </span>
+              </Link>
             </li>
           );
         })}

--- a/src/components/schedule/ScheduleTable.tsx
+++ b/src/components/schedule/ScheduleTable.tsx
@@ -47,6 +47,7 @@ export const ScheduleTable = ({
               {table.days.map((day) => (
                 <th
                   key={day.iso}
+                  scope="col"
                   className={cn(
                     "border border-brand-700 bg-brand-600 px-2 py-2 text-center text-xs font-semibold text-white",
                     isSameDay(day.date, today) && "bg-brand-500",
@@ -63,7 +64,10 @@ export const ScheduleTable = ({
           <tbody>
             {table.slots.map((slot) => (
               <tr key={slot}>
-                <th className="border border-brand-700 bg-brand-600 px-2 py-3 text-center text-sm font-semibold text-white tabular-nums">
+                <th
+                  scope="row"
+                  className="border border-brand-700 bg-brand-600 px-2 py-3 text-center text-sm font-semibold text-white tabular-nums"
+                >
                   {slot}
                 </th>
                 {table.days.map((day) => {


### PR DESCRIPTION
…сания

NavLink проставляет aria-current только по собственному совпадению маршрута, поэтому на вложенных экранах вкладка «Другое» подсвечивалась визуально, но не помечалась для скринридера. Активность вкладок теперь считается явно через matchPath.

Ячейкам с номером пары добавлен scope="row", дням недели — scope="col".

Тесты пагинации оценок приведены к фактической подписи кнопки догрузки.